### PR TITLE
Fix path for countrycode.css registration

### DIFF
--- a/src/FilamentCountryCodeFieldServiceProvider.php
+++ b/src/FilamentCountryCodeFieldServiceProvider.php
@@ -55,7 +55,7 @@ class FilamentCountryCodeFieldServiceProvider extends PackageServiceProvider
         });
 
         FilamentAsset::register([
-            Css::make('countrycode', __DIR__.'./../dist/countrycode.css'),
+            Css::make('countrycode', __DIR__.'/../dist/countrycode.css'),
         ], 'tapp/'.static::$name);
     }
 }


### PR DESCRIPTION
# Details

Remove extra dot in CSS path that prevents assets from loading on Windows. This unifies the path style with the rest of the Service Provider.