### PR TITLE
Drop PHP 8.2, add PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
+        php: [8.5, 8.4, 8.3]
         laravel: [12.*, 11.*]
         stability: [prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "source": "https://github.com/TappNetwork/filament-country-code-field"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/filament": "^5.0|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

- Raises minimum PHP requirement from 8.2 to 8.3 in `composer.json`
- Adds PHP 8.5 to the CI test matrix and removes 8.2 in `.github/workflows/run-tests.yml`

## Test plan
- [ ] CI runs tests against PHP 8.3, 8.4, and 8.5
- [ ] No tests run against PHP 8.2