### PR TITLE
Add Laravel 13 test support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          composer config audit.block-insecure false
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer require "orchestra/testbench:${{ matrix.testbench }}" --dev --no-interaction --no-update
           composer require "pestphp/pest:${{ matrix.pest }}" --dev --no-interaction --no-update
@@ -62,4 +63,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --no-coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,10 +23,13 @@ jobs:
         include:
           - laravel: 13.*
             testbench: 11.*
+            pest: ^4.0
           - laravel: 12.*
             testbench: 10.*
+            pest: ^3.0
           - laravel: 11.*
             testbench: 9.*
+            pest: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -48,7 +51,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require "orchestra/testbench:${{ matrix.testbench }}" --dev --no-interaction --no-update
+          composer require "pestphp/pest:${{ matrix.pest }}" --dev --no-interaction --no-update
+          composer require "pestphp/pest-plugin-arch:${{ matrix.pest }}" --dev --no-interaction --no-update
+          composer require "pestphp/pest-plugin-laravel:${{ matrix.pest }}" --dev --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^3.0||^2.34",
         "pestphp/pest-plugin-arch": "^3.0||^2.7",
         "pestphp/pest-plugin-laravel": "^3.0||^2.3",

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
-        "pestphp/pest": "^3.0||^2.34",
-        "pestphp/pest-plugin-arch": "^3.0||^2.7",
-        "pestphp/pest-plugin-laravel": "^3.0||^2.3",
+        "pestphp/pest": "^4.0||^3.0||^2.34",
+        "pestphp/pest-plugin-arch": "^4.0||^3.0||^2.7",
+        "pestphp/pest-plugin-laravel": "^4.0||^3.0||^2.3",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0"


### PR DESCRIPTION
## Summary
- allow orchestra/testbench 11 for Laravel 13 compatibility
- add Laravel 13 / Testbench 11 to the test matrix

## Local verification
- composer validate --strict --no-check-publish
- composer update --prefer-stable --prefer-dist --no-interaction --no-progress
- vendor/bin/pest --ci
