### PR TITLE
Support Pest 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
-        "pestphp/pest": "^4.0||^3.0||^2.34",
-        "pestphp/pest-plugin-arch": "^4.0||^3.0||^2.7",
-        "pestphp/pest-plugin-laravel": "^4.0||^3.0||^2.3",
+        "pestphp/pest": "^4.0||^3.0||^2.34|^5.0",
+        "pestphp/pest-plugin-arch": "^4.0||^3.0||^2.7|^5.0",
+        "pestphp/pest-plugin-laravel": "^4.0||^3.0||^2.3|^5.0",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0"


### PR DESCRIPTION
## Summary
- Allow Pest 5 in composer dev constraints.
- Include matching Pest plugin constraints where this package uses Pest plugins.
- Keep existing Pest version support in place for current stable installs.

## Verification
- `composer validate --no-check-publish`
- `composer update --dry-run`

Note: Pest 5 is currently available to Composer as a dev line, so this prepares the package constraints while preserving current stable Pest 4 resolution.
